### PR TITLE
fix(chat): handle empty LLM reply and raise tool-loop cap

### DIFF
--- a/klatrebot_v2/cogs/chat.py
+++ b/klatrebot_v2/cogs/chat.py
@@ -36,6 +36,9 @@ class ChatCog(commands.Cog):
         text = result.text
         if result.sources:
             text += f"\n\n_Kilder: {', '.join(result.sources[:3])}_"
+        if not text.strip():
+            logger.warning("llm.reply empty text user_id=%d", ctx.author.id)
+            text = "Jeg kunne ikke finde på et svar. Prøv igen."
         await ctx.reply(
             text,
             allowed_mentions=discord.AllowedMentions(

--- a/klatrebot_v2/llm/chat.py
+++ b/klatrebot_v2/llm/chat.py
@@ -135,7 +135,7 @@ async def reply(
         text={"verbosity": "medium"},
         include=["web_search_call.action.sources"],
     )
-    for _ in range(4):
+    for _ in range(8):
         if memory_run_id is None:
             break
         tool_outputs = []


### PR DESCRIPTION
ctx.reply crashed with HTTP 400 (50006 "Cannot send an empty message") when the Responses API returned no output_text — e.g. the memory tool loop exhausted its 4-iteration cap before producing a final answer.

- ChatCog.gpt: fall back to a Danish "no answer" message when result.text is blank, so the bot stays alive instead of raising CommandInvokeError.
- llm.chat.reply: bump tool-call loop cap from 4 to 8 to give the model more headroom for memory tool chains.