### PR TITLE
feat(klatretid): seasonal mode shows climbing location on embed

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -16,6 +16,10 @@ KLATRETID_DAYS=[0,3]
 KLATRETID_POST_HOUR=17
 KLATRETID_START_HOUR=20
 
+# Seasonal mode: show climbing location on the klatretid embed (weekday Mon=0..Sun=6)
+SEASONAL_ENABLED=false
+SEASONAL_LOCATIONS={"0":"Sydhavn","3":"Vanløse"}
+
 GPT_RECENT_MESSAGE_COUNT=25
 RATE_LIMIT_PER_USER_PER_HOUR=30
 LOG_LEVEL=INFO

--- a/klatrebot_v2/cogs/attendance.py
+++ b/klatrebot_v2/cogs/attendance.py
@@ -12,10 +12,17 @@ from klatrebot_v2.tasks import (
     DEFAULT_KLATRETID_DESCRIPTION,
     build_klatretid_embed,
     post_klatretid_embed_in,
+    seasonal_location_for,
 )
 
 
 logger = logging.getLogger(__name__)
+
+
+def _location_for_session_date(date_local: str) -> str | None:
+    """Seasonal location for a session's local date string (YYYY-MM-DD)."""
+    weekday = datetime.strptime(date_local, "%Y-%m-%d").weekday()
+    return seasonal_location_for(weekday)
 
 
 def _today_local_str() -> str:
@@ -107,8 +114,9 @@ class AttendanceCog(commands.Cog):
         yes, no = await att_db.tally(self.bot.db_conn, session_id=sess.id)
         bailers = await att_db.bailers(self.bot.db_conn, session_id=sess.id)
         bailer_ids = {u.discord_user_id for u in bailers}
+        location = _location_for_session_date(sess.date_local)
         if not yes and not no:
-            embed = build_klatretid_embed()
+            embed = build_klatretid_embed(location=location)
         else:
             yes_names = ", ".join(
                 (f"{u.display_name} 🐔" if u.discord_user_id in bailer_ids else u.display_name)
@@ -123,7 +131,7 @@ class AttendanceCog(commands.Cog):
                 f"\n✅: {yes_names}"
                 f"\n❌: {no_names}"
             )
-            embed = build_klatretid_embed(description=description)
+            embed = build_klatretid_embed(description=description, location=location)
         try:
             await msg.edit(embed=embed)
         except discord.HTTPException:

--- a/klatrebot_v2/settings.py
+++ b/klatrebot_v2/settings.py
@@ -29,6 +29,11 @@ class Settings(BaseSettings):
     klatretid_post_hour: int = 17
     klatretid_start_hour: int = 20
 
+    # Seasonal mode: show climbing location on the klatretid embed.
+    # Weekday (Mon=0 … Sun=6) -> location name.
+    seasonal_enabled: bool = False
+    seasonal_locations: dict[int, str] = {0: "Sydhavn", 3: "Vanløse"}
+
     gpt_recent_message_count: int = 25
     rate_limit_per_user_per_hour: int = 30
     log_level: str = "INFO"

--- a/klatrebot_v2/tasks.py
+++ b/klatrebot_v2/tasks.py
@@ -50,11 +50,21 @@ DEFAULT_KLATRETID_DESCRIPTION = "@everyone Hva sker der? er i.. er i glar?\n"
 KLATRETID_GIF_URL = "https://i.imgur.com/9uMGPae.gif"
 
 
-def build_klatretid_embed(*, description: str | None = None) -> discord.Embed:
-    embed = discord.Embed(
-        title="Klatretid!",
-        description=description or DEFAULT_KLATRETID_DESCRIPTION,
-    )
+def seasonal_location_for(weekday: int) -> str | None:
+    """Climbing location for a weekday when seasonal mode is on, else None."""
+    s = get_settings()
+    if not s.seasonal_enabled:
+        return None
+    return s.seasonal_locations.get(weekday)
+
+
+def build_klatretid_embed(
+    *, description: str | None = None, location: str | None = None
+) -> discord.Embed:
+    body = description or DEFAULT_KLATRETID_DESCRIPTION
+    if location:
+        body = f"{body}\nLokation: {location}"
+    embed = discord.Embed(title="Klatretid!", description=body)
     embed.set_image(url=KLATRETID_GIF_URL)
     return embed
 
@@ -67,7 +77,8 @@ async def post_klatretid_embed_in(
 ) -> None:
     """Post klatretid embed + create attendance session in `channel`."""
     s = get_settings()
-    embed = build_klatretid_embed()
+    location = seasonal_location_for(post_time_local.weekday())
+    embed = build_klatretid_embed(location=location)
     msg = await channel.send(embed=embed)
     await msg.add_reaction("✅")
     await msg.add_reaction("❌")

--- a/tests/unit/test_seasonal_location.py
+++ b/tests/unit/test_seasonal_location.py
@@ -1,0 +1,46 @@
+def _enable_seasonal(monkeypatch, *, enabled):
+    monkeypatch.setenv("DISCORD_KEY", "x")
+    monkeypatch.setenv("OPENAI_KEY", "x")
+    monkeypatch.setenv("DISCORD_MAIN_CHANNEL_ID", "1")
+    monkeypatch.setenv("DISCORD_SANDBOX_CHANNEL_ID", "2")
+    monkeypatch.setenv("ADMIN_USER_ID", "3")
+    if enabled:
+        monkeypatch.setenv("SEASONAL_ENABLED", "true")
+    from klatrebot_v2.settings import get_settings
+    get_settings.cache_clear()
+
+
+def test_seasonal_off_by_default(monkeypatch):
+    _enable_seasonal(monkeypatch, enabled=False)
+    from klatrebot_v2.settings import get_settings
+    from klatrebot_v2.tasks import seasonal_location_for
+    assert get_settings().seasonal_enabled is False
+    assert seasonal_location_for(0) is None
+
+
+def test_seasonal_location_when_enabled(monkeypatch):
+    _enable_seasonal(monkeypatch, enabled=True)
+    from klatrebot_v2.tasks import seasonal_location_for
+    assert seasonal_location_for(0) == "Sydhavn"   # Monday
+    assert seasonal_location_for(3) == "Vanløse"   # Thursday
+    assert seasonal_location_for(1) is None         # Tuesday (unmapped)
+
+
+def test_embed_appends_lokation_line():
+    from klatrebot_v2.tasks import build_klatretid_embed
+    embed = build_klatretid_embed(location="Sydhavn")
+    assert "Lokation: Sydhavn" in embed.description
+    assert not embed.fields
+
+
+def test_embed_no_lokation_line_when_location_none():
+    from klatrebot_v2.tasks import build_klatretid_embed
+    embed = build_klatretid_embed()
+    assert "Lokation" not in (embed.description or "")
+
+
+def test_location_for_session_date_parses_weekday(monkeypatch):
+    _enable_seasonal(monkeypatch, enabled=True)
+    from klatrebot_v2.cogs.attendance import _location_for_session_date
+    assert _location_for_session_date("2026-06-15") == "Sydhavn"  # Monday
+    assert _location_for_session_date("2026-06-16") is None        # Tuesday


### PR DESCRIPTION
## What
Optional seasonal mode appends climbing location to the klatretid embed:
- Monday -> Sydhavn
- Thursday -> Vanløse

Off by default. Rendered as a `Lokation: <sted>` line in the embed description.

## How
- `settings.py` - `seasonal_enabled` + `seasonal_locations` (weekday Mon=0..Sun=6 -> name).
- `tasks.py` - `seasonal_location_for(weekday)`; `build_klatretid_embed(..., location=...)` appends the line; initial post resolves from post weekday.
- `cogs/attendance.py` - `_location_for_session_date` re-derives from session date so the line survives reaction edits in `_refresh_embed`.
- `.env.example` - documents `SEASONAL_ENABLED` / `SEASONAL_LOCATIONS`.

## Enabling
```
SEASONAL_ENABLED=true
SEASONAL_LOCATIONS={"0":"Sydhavn","3":"Vanløse"}   # optional override
```

## Tests
`tests/unit/test_seasonal_location.py` - 5 tests (default-off, enabled mapping, embed line render/omit, session-date parsing). Full suite green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)