### PR TITLE
fix(chat): suppress link embeds in GPT replies

### DIFF
--- a/klatrebot_v2/cogs/chat.py
+++ b/klatrebot_v2/cogs/chat.py
@@ -41,6 +41,7 @@ class ChatCog(commands.Cog):
             text = "Jeg kunne ikke finde på et svar. Prøv igen."
         await ctx.reply(
             text,
+            suppress_embeds=True,
             allowed_mentions=discord.AllowedMentions(
                 users=True, everyone=False, roles=False, replied_user=True
             ),

--- a/tests/unit/test_chat_cog.py
+++ b/tests/unit/test_chat_cog.py
@@ -1,0 +1,39 @@
+from contextlib import asynccontextmanager
+from types import SimpleNamespace
+from unittest.mock import AsyncMock, MagicMock
+
+from klatrebot_v2.cogs import chat as chat_cog
+from klatrebot_v2.llm.chat import ChatReply
+
+
+async def test_gpt_reply_suppresses_link_embeds(monkeypatch):
+    monkeypatch.setattr(chat_cog.ratelimit, "check_and_record", lambda _user_id: True)
+    monkeypatch.setattr(
+        chat_cog.chat,
+        "reply",
+        AsyncMock(
+            return_value=ChatReply(
+                text="Et svar med en kilde.",
+                sources=["https://example.com/source"],
+            )
+        ),
+    )
+
+    @asynccontextmanager
+    async def typing():
+        yield
+
+    ctx = SimpleNamespace(
+        author=SimpleNamespace(id=42),
+        channel=SimpleNamespace(id=7),
+        message=SimpleNamespace(mentions=[]),
+        typing=typing,
+        reply=AsyncMock(),
+    )
+    cog = chat_cog.ChatCog(MagicMock())
+
+    await chat_cog.ChatCog.gpt.callback(cog, ctx, question="Hvad sker der?")
+
+    ctx.reply.assert_awaited_once()
+    assert ctx.reply.await_args.kwargs["suppress_embeds"] is True
+    assert "https://example.com/source" in ctx.reply.await_args.args[0]


### PR DESCRIPTION
## Summary

- Suppress Discord link-preview embeds on successful `!gpt` replies.
- Keep source URLs visible and clickable.
- Add regression coverage for the Discord reply arguments.

## Why

Web-search responses can include several source URLs. Discord expands those links into large preview cards, causing a single bot response to occupy excessive space in the channel.

## Impact

Only `!gpt` responses suppress previews. Other bot messages and ordinary channel links are unchanged.

## Validation

- `poetry run pytest -v`
- 111 passed, 1 integration test skipped because live Discord/OpenAI credentials were unavailable.
