### PR TITLE
fix(llm): report only cited web sources

### DIFF
--- a/klatrebot_v2/llm/chat.py
+++ b/klatrebot_v2/llm/chat.py
@@ -38,16 +38,23 @@ class ChatReply(BaseModel):
 
 
 def _extract_sources(resp) -> list[str]:
-    """Pull URLs from `web_search_call.action.sources`. Returns [] if not present."""
-    out = getattr(resp, "output", None) or []
-    for item in out:
-        if getattr(item, "type", None) == "web_search_call":
-            action = getattr(item, "action", None)
-            sources = getattr(action, "sources", None) if action else None
-            if not sources:
-                return []
-            return [getattr(s, "url", "") for s in sources if getattr(s, "url", None)]
-    return []
+    """Return only URLs explicitly cited in the final answer text."""
+    sources: list[str] = []
+    seen: set[str] = set()
+    for item in getattr(resp, "output", None) or []:
+        if getattr(item, "type", None) != "message":
+            continue
+        for content in getattr(item, "content", None) or []:
+            if getattr(content, "type", None) != "output_text":
+                continue
+            for annotation in getattr(content, "annotations", None) or []:
+                if getattr(annotation, "type", None) != "url_citation":
+                    continue
+                url = getattr(annotation, "url", None)
+                if url and url not in seen:
+                    seen.add(url)
+                    sources.append(url)
+    return sources
 
 
 def _extract_function_calls(resp) -> list[dict]:
@@ -133,7 +140,6 @@ async def reply(
         tools=tools,
         reasoning={"effort": "low"},
         text={"verbosity": "medium"},
-        include=["web_search_call.action.sources"],
     )
     for _ in range(8):
         if memory_run_id is None:
@@ -165,7 +171,6 @@ async def reply(
             previous_response_id=getattr(resp, "id"),
             reasoning={"effort": "low"},
             text={"verbosity": "medium"},
-            include=["web_search_call.action.sources"],
         )
     return ChatReply(text=resp.output_text or "", sources=_extract_sources(resp))
 

--- a/tests/unit/test_chat.py
+++ b/tests/unit/test_chat.py
@@ -47,7 +47,7 @@ async def test_reply_returns_chat_reply(monkeypatch, tmp_path, fake_response, db
     assert "hvad så" in call_kwargs["input"]
     assert "42" in call_kwargs["input"]
     assert call_kwargs["tools"] == [{"type": "web_search"}]
-    assert "web_search_call.action.sources" in call_kwargs["include"]
+    assert "include" not in call_kwargs
 
 
 async def test_reply_includes_recent_context(monkeypatch, tmp_path, fake_response, db):
@@ -321,13 +321,25 @@ def test_extract_sources_from_response():
 
     fake_resp = MagicMock()
     fake_resp.output = [
-        MagicMock(type="message"),  # not a search call
         MagicMock(
             type="web_search_call",
             action=MagicMock(sources=[
-                MagicMock(url="https://a.dk"),
-                MagicMock(url="https://b.dk"),
+                MagicMock(url="https://incidental.example"),
             ]),
+        ),
+        MagicMock(
+            type="message",
+            content=[
+                MagicMock(
+                    type="output_text",
+                    annotations=[
+                        MagicMock(type="url_citation", url="https://a.dk"),
+                        MagicMock(type="url_citation", url="https://b.dk"),
+                        MagicMock(type="url_citation", url="https://a.dk"),
+                        MagicMock(type="file_citation", url=None),
+                    ],
+                )
+            ],
         ),
     ]
     assert _extract_sources(fake_resp) == ["https://a.dk", "https://b.dk"]


### PR DESCRIPTION
## Summary

- Build the `!gpt` source footer from final-answer `url_citation` annotations.
- Ignore incidental URLs returned by the broader web-search action.
- Deduplicate cited URLs while preserving citation order.
- Stop requesting the unused `web_search_call.action.sources` payload.

## Root cause

KlatreBot appended the first URLs encountered by the web-search tool, even when the final response did not rely on them. This produced unrelated or low-value links in the `_Kilder` footer.

## User impact

The footer now contains only sources explicitly cited by the final answer, reducing irrelevant links while retaining clickable evidence.

## Validation

- `poetry run pytest -v`
- 111 passed, 1 integration test skipped because live Discord/OpenAI credentials were unavailable.
